### PR TITLE
Add uploaded filename option and switch to opaque provider id

### DIFF
--- a/cmd/replica-cli/main.go
+++ b/cmd/replica-cli/main.go
@@ -34,19 +34,19 @@ func mainErr() error {
 	}
 	app.Command("upload", "uploads a file to S3 and returns the S3 key", func(cmd *cli.Cmd) {
 		file := cmd.StringArg("FILE", "", "file to upload")
-		provider := cmd.StringOpt("p provider", "", "Replica content provider name")
-		id := cmd.StringOpt("i id", "", "Replica content provider id")
+		providerID := cmd.StringOpt("p provider-id", "", "Replica content provider and id (eg youtube-IDHERE")
+		filename := cmd.StringOpt("n filename", "", "Optional filename to be uploaded as. If not provided, it will use the filename of the specified FILE")
 		cmd.Action = func() {
 			checkAction(func() error {
 				var uConfig replica.UploadConfig
-				if *id != "" && *provider != "" {
+				if *providerID != "" {
 					uConfig = &replica.ProviderUploadConfig{
-						File:     *file,
-						Provider: *provider,
-						ID:       *id,
+						File:       *file,
+						ProviderID: *providerID,
+						Name:       *filename,
 					}
 				} else {
-					uConfig = replica.NewUUIDUploadConfig(*file)
+					uConfig = replica.NewUUIDUploadConfig(*file, *filename)
 				}
 
 				output, err := replicaClient.UploadFile(uConfig)
@@ -58,7 +58,7 @@ func mainErr() error {
 				return nil
 			}())
 		}
-		cmd.Spec = "[-i -p] FILE"
+		cmd.Spec = "[-p] [-n] FILE"
 	})
 	app.Command("get-torrent", "retrieve BitTorrent metainfo for a Replica S3 key", func(cmd *cli.Cmd) {
 		name := cmd.StringArg("NAME", "", "Replica S3 object name")

--- a/replica.go
+++ b/replica.go
@@ -80,9 +80,9 @@ type UploadConfig interface {
 }
 
 type ProviderUploadConfig struct {
-	File     string
-	Provider string
-	ID       string
+	File       string
+	ProviderID string
+	Name       string
 }
 
 func (pc *ProviderUploadConfig) FullPath() string {
@@ -90,36 +90,38 @@ func (pc *ProviderUploadConfig) FullPath() string {
 }
 
 func (pc *ProviderUploadConfig) Filename() string {
+	if pc.Name != "" {
+		return pc.Name
+	}
 	return filepath.Base(pc.File)
 }
 
 func (pc *ProviderUploadConfig) GetPrefix() UploadPrefix {
 	return UploadPrefix{ProviderPrefix{
-		provider: pc.Provider,
-		id:       pc.ID,
+		providerID: pc.ProviderID,
 	}}
 }
 
-func (me *ProviderUploadConfig) UpdateFilename(f string) {
-	me.File = f
-}
-
 type uuidUploadConfig struct {
-	File string
+	file string
 	uuid uuid.UUID
+	name string
 }
 
-func NewUUIDUploadConfig(f string) *uuidUploadConfig {
+func NewUUIDUploadConfig(f string, name string) *uuidUploadConfig {
 	u := uuid.New()
-	return &uuidUploadConfig{File: f, uuid: u}
+	return &uuidUploadConfig{file: f, uuid: u}
 }
 
 func (uc *uuidUploadConfig) FullPath() string {
-	return uc.File
+	return uc.file
 }
 
 func (uc *uuidUploadConfig) Filename() string {
-	return filepath.Base(uc.File)
+	if uc.name != "" {
+		return uc.name
+	}
+	return filepath.Base(uc.file)
 }
 
 func (uc *uuidUploadConfig) GetPrefix() UploadPrefix {
@@ -154,6 +156,7 @@ func (r *Client) Upload(read io.Reader, uConfig UploadConfig) (output UploadOutp
 
 	// Whether we fail or not from this point, the prefix could be useful to the caller.
 	output.Upload = r.NewUpload(uConfig)
+
 	uploader := s3manager.NewUploader(sess)
 	_, err = uploader.Upload(&s3manager.UploadInput{
 		Bucket: aws.String(r.BucketName),

--- a/upload-prefix.go
+++ b/upload-prefix.go
@@ -1,7 +1,6 @@
 package replica
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/google/uuid"
@@ -24,12 +23,11 @@ func (me UUIDPrefix) PrefixString() string {
 }
 
 type ProviderPrefix struct {
-	provider string
-	id       string
+	providerID string
 }
 
 func (me ProviderPrefix) PrefixString() string {
-	return fmt.Sprintf("%v-%v", me.provider, me.id)
+	return me.providerID
 }
 
 func (me UploadPrefix) String() string {


### PR DESCRIPTION
I realized that I hadn't made the change to opaque provider ids here yet. I've also added an optional `name` flag/option which lets the user specify a upload filename because it seemed like I might want to use that for the replica lambdas work.

Lemme know if you'd prefer to consider them separately.


Thanks!