### PR TITLE
Fix NewUUIDUploadConfig bug

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -15,7 +15,7 @@ func TestCreateLink(t *testing.T) {
 	var infoHash torrent.InfoHash
 	filename := "nice name"
 	require.NoError(t, infoHash.FromHexString(infoHashHex))
-	upload := DefaultEndpoint.NewUpload(NewUUIDUploadConfig(filename))
+	upload := DefaultEndpoint.NewUpload(NewUUIDUploadConfig("", filename))
 	link := CreateLink(infoHash, upload, []string{"nice name"})
 	uuidString := upload.String()
 	require.EqualValues(t,

--- a/replica.go
+++ b/replica.go
@@ -108,9 +108,13 @@ type uuidUploadConfig struct {
 	name string
 }
 
-func NewUUIDUploadConfig(f string, name string) *uuidUploadConfig {
+// NewUUIDUploadConfig creates a new uuidUploadConfig which implements the UploadConfig interface
+// The first parameter f will be used strictly for potentially opening a local file and can be left blank
+// The second parameter n will be used as the name of the upload. If it is left blank, the name of the
+// upload will come from the first parameter's "base" name
+func NewUUIDUploadConfig(f, n string) *uuidUploadConfig {
 	u := uuid.New()
-	return &uuidUploadConfig{file: f, uuid: u}
+	return &uuidUploadConfig{file: f, uuid: u, name: n}
 }
 
 func (uc *uuidUploadConfig) FullPath() string {


### PR DESCRIPTION
Fixes a silly mistake I made in https://github.com/getlantern/replica/pull/12

I'm still not 100% in love with the API (it always seems a little weird to me potentially having to pass an empty string as a parameter), but I think it could be good enough?

I mostly really want to be able to cut a new v0.4.1 here and then be able to pull these changes into flashlight