### PR TITLE
[il4945] Add and use DynamicEndpoint in lieu of constant URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/anacrolix/envpprof v1.1.0
 	github.com/anacrolix/torrent v1.15.1-0.20200513043326-587f28d2fa30
 	github.com/aws/aws-sdk-go v1.28.9
-	github.com/frankban/quicktest v1.11.3
 	github.com/google/uuid v1.1.1
 	github.com/leanovate/gopter v0.2.9
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -145,9 +145,8 @@ github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHj
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
+github.com/frankban/quicktest v1.9.0 h1:jfEA+Psfr/pHsRJYPpHiNu7PGJnGctNxvTaM3K1EyXk=
 github.com/frankban/quicktest v1.9.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
-github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
-github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -196,9 +195,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -248,9 +246,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=

--- a/replica_test.go
+++ b/replica_test.go
@@ -4,18 +4,25 @@ import (
 	"net/url"
 	"testing"
 
-	qt "github.com/frankban/quicktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppendFileNameUploadUrl(t *testing.T) {
-	c := qt.New(t)
-	base, err := url.Parse("https://some.service")
-	c.Assert(err, qt.IsNil)
-	c.Check(serviceUploadUrl(base, "lmao").String(), qt.Equals, "https://some.service/upload/lmao")
-	// There's no neat way to handle '/' in the file name, except maybe to accept a variable number
-	// of path segments in the handler in the upload service or do the URL path encoding manually.
-	// But also having directory separators inside file path components in metainfos will get risky
-	// too. So while we handle this, it will just result in a 404 with the current implementation in
-	// replica-rust.
-	c.Check(serviceUploadUrl(base, "hello/world").String(), qt.Equals, "https://some.service/upload/hello/world")
+	fetchBaseUrlFunc := func() *url.URL {
+		u, err := url.Parse("https://some.service")
+		require.NoError(t, err)
+		return u
+	}
+	require.Equal(t,
+		"https://some.service/upload/lmao",
+		serviceUploadUrl(fetchBaseUrlFunc, "lmao").String())
+	// There's no neat way to handle '/' in the file name, except maybe to
+	// accept a variable number of path segments in the handler in the upload
+	// service or do the URL path encoding manually.  But also having directory
+	// separators inside file path components in metainfos will get risky too.
+	// So while we handle this, it will just result in a 404 with the current
+	// implementation in replica-rust.
+	require.Equal(t,
+		"https://some.service/upload/hello/world",
+		serviceUploadUrl(fetchBaseUrlFunc, "hello/world").String())
 }

--- a/service.go
+++ b/service.go
@@ -5,14 +5,10 @@ import (
 	"path"
 )
 
-// This exists for anything that doesn't have configuration but expects to connect to an arbitrary
-// replica-rust service. At least in flashlight, this is provided by configuration instead.
-var GlobalChinaDefaultServiceUrl = &url.URL{
-	Scheme: "https",
-	Host:   "replica-search.lantern.io",
-}
-
-// Interface to the replica-rust/"Replica service".
+// This exists for anything that doesn't have configuration but expects to
+// connect to an arbitrary replica-rust service. At least in flashlight, this
+// is provided by configuration instead.
+const DefaultReplicaRustEndpoint string = "https://replica-search.lantern.io"
 
 type ServiceUploadOutput struct {
 	Link       string `json:"link"`
@@ -21,10 +17,12 @@ type ServiceUploadOutput struct {
 }
 
 // Completes the upload endpoint URL with the file-name, per the replica-rust upload endpoint API.
-func serviceUploadUrl(base *url.URL, fileName string) *url.URL {
-	return base.ResolveReference(&url.URL{Path: path.Join("upload", fileName)})
+func serviceUploadUrl(fetchBaseUrlFunc func() *url.URL, fileName string) *url.URL {
+	return fetchBaseUrlFunc().
+		ResolveReference(&url.URL{Path: path.Join("upload", fileName)})
 }
 
-func serviceDeleteUrl(base *url.URL) *url.URL {
-	return base.ResolveReference(&url.URL{Path: "delete"})
+func serviceDeleteUrl(fetchBaseUrlFunc func() *url.URL) *url.URL {
+	return fetchBaseUrlFunc().
+		ResolveReference(&url.URL{Path: "delete"})
 }


### PR DESCRIPTION
Related to https://github.com/getlantern/grants/issues/382

Adds a `DynamicEndpoint` structure to automatically update replica-rust's endpoint based on geolocation.

Also, I removed the usage of `quicktest` package: since we're sing strechr's `testify` package for testing, let's stick with that for everything.