### PR TITLE
[service] Make ReplicaServiceEndpoint a function

### DIFF
--- a/replica.go
+++ b/replica.go
@@ -32,7 +32,7 @@ func CreateLink(ih torrent.InfoHash, infoName Prefix, filePath []string) string 
 
 type ServiceClient struct {
 	// This should be a URL to handle uploads. The specifics are in replica-rust.
-	ReplicaServiceEndpoint *url.URL
+	ReplicaServiceEndpoint func() *url.URL
 	HttpClient             *http.Client
 }
 

--- a/replica_test.go
+++ b/replica_test.go
@@ -4,18 +4,25 @@ import (
 	"net/url"
 	"testing"
 
-	qt "github.com/frankban/quicktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppendFileNameUploadUrl(t *testing.T) {
-	c := qt.New(t)
-	base, err := url.Parse("https://some.service")
-	c.Assert(err, qt.IsNil)
-	c.Check(serviceUploadUrl(base, "lmao").String(), qt.Equals, "https://some.service/upload/lmao")
-	// There's no neat way to handle '/' in the file name, except maybe to accept a variable number
-	// of path segments in the handler in the upload service or do the URL path encoding manually.
-	// But also having directory separators inside file path components in metainfos will get risky
-	// too. So while we handle this, it will just result in a 404 with the current implementation in
-	// replica-rust.
-	c.Check(serviceUploadUrl(base, "hello/world").String(), qt.Equals, "https://some.service/upload/hello/world")
+	fetchBaseUrlFunc := func() *url.URL {
+		u, err := url.Parse("https://some.service")
+		require.NoError(t, err)
+		return u
+	}
+	require.Equal(t,
+		"https://some.service/upload/lmao",
+		serviceUploadUrl(fetchBaseUrlFunc, "lmao").String())
+	// There's no neat way to handle '/' in the file name, except maybe to
+	// accept a variable number of path segments in the handler in the upload
+	// service or do the URL path encoding manually.  But also having directory
+	// separators inside file path components in metainfos will get risky too.
+	// So while we handle this, it will just result in a 404 with the current
+	// implementation in replica-rust.
+	require.Equal(t,
+		"https://some.service/upload/hello/world",
+		serviceUploadUrl(fetchBaseUrlFunc, "hello/world").String())
 }

--- a/service.go
+++ b/service.go
@@ -21,10 +21,10 @@ type ServiceUploadOutput struct {
 }
 
 // Completes the upload endpoint URL with the file-name, per the replica-rust upload endpoint API.
-func serviceUploadUrl(base *url.URL, fileName string) *url.URL {
-	return base.ResolveReference(&url.URL{Path: path.Join("upload", fileName)})
+func serviceUploadUrl(base func() *url.URL, fileName string) *url.URL {
+	return base().ResolveReference(&url.URL{Path: path.Join("upload", fileName)})
 }
 
-func serviceDeleteUrl(base *url.URL) *url.URL {
-	return base.ResolveReference(&url.URL{Path: "delete"})
+func serviceDeleteUrl(base func() *url.URL) *url.URL {
+	return base().ResolveReference(&url.URL{Path: "delete"})
 }


### PR DESCRIPTION
Related to https://github.com/getlantern/grants/issues/382

Adds a `DynamicEndpoint` structure to automatically update replica-rust's endpoint based on geolocation.

Also, I removed the usage of `quicktest` package: since we're sing strechr's `testify` package for testing, let's stick with that for everything.