### PR TITLE
[torrent_cfg] Add readonlynode flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/anacrolix/confluence v1.8.1
+	github.com/anacrolix/dht/v2 v2.10.6-0.20211007004332-99263ec9c1c8
 	github.com/anacrolix/log v0.10.0
 	github.com/anacrolix/torrent v1.35.0
 	github.com/aws/aws-sdk-go v1.28.9


### PR DESCRIPTION
Related to https://github.com/getlantern/grants/issues/430

- Adds a readOnlyNode flag to disable seeding and makes the [dht node passive](https://www.bittorrent.org/beps/bep_0043.html)