### PR TITLE
[server] add /clear_uploads route

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -582,12 +582,23 @@ func (me *HttpHandler) handleUploads(rw InstrumentedResponseWriter, r *http.Requ
 	return encodeJsonResponse(rw, resp)
 }
 
+func (me *HttpHandler) handleClearUploads(rw InstrumentedResponseWriter, r *http.Request) error {
+	os.RemoveAll(me.uploadsDir)
+	err := os.MkdirAll(me.uploadsDir, 0700)
+	if err != nil {
+		return errors.New("mkdir uploadsDir %v: %v", me.uploadsDir, err)
+	}
+
+	log.Debugf("Cleared uploads directory")
+	rw.WriteHeader(http.StatusOK)
+	return nil
+}
+
 func (me *HttpHandler) handleDelete(rw InstrumentedResponseWriter, r *http.Request) (err error) {
 	link := r.URL.Query().Get("link")
 	m, err := metainfo.ParseMagnetUri(link)
 	if err != nil {
 		return handlerError{http.StatusBadRequest, errors.New("parsing magnet link: %v", err)}
-
 	}
 
 	var upload service.Upload


### PR DESCRIPTION
Related to https://github.com/getlantern/grants/issues/440

As @myleshorton requested, Replica mobile should not log uploads. This'll help nuke the uploads when they're done.

An alternative is to send a flag to `/upload` flag to never log the torrent in the first place. Both are okay for me.

@anacrolix What do you think?

/CC @oxtoacart 