### PR TITLE
[server] Change StoreMetainfoFileAndTokenLocally to No*

### DIFF
--- a/server/instrumented_response_writer.go
+++ b/server/instrumented_response_writer.go
@@ -41,5 +41,4 @@ func (me *NewHttpHandlerInput) SetDefaults() {
 			return false
 		}
 	}
-	me.StoreMetainfoFileAndTokenLocally = true
 }

--- a/server/server.go
+++ b/server/server.go
@@ -107,11 +107,12 @@ type NewHttpHandlerInput struct {
 	// Retain a copy of upload file data. This would save downloading our own uploaded content if we
 	// intend to seed it.
 	StoreUploadsLocally bool
-	// Create a metainfo file and admin token
-	// Admin token is used if the uploader wants to delete their file later on
-	StoreMetainfoFileAndTokenLocally bool
-	OnRequestReceived                func(handler string, extraInfo string)
-	GlobalConfig                     func() ReplicaOptions
+	// Create a metainfo file and admin token.
+	// Admin token is used if the uploader wants to delete their file later on.
+	// By default, store metainfo and tokens locally
+	NoStoreMetainfoFileAndTokenLocally bool
+	OnRequestReceived                  func(handler string, extraInfo string)
+	GlobalConfig                       func() ReplicaOptions
 	// This sets the DHT node as 'read-only' as well as disable seeding in the
 	// torrent client
 	ReadOnlyNode bool
@@ -485,7 +486,7 @@ func (me *HttpHandler) handleUpload(rw InstrumentedResponseWriter, r *http.Reque
 	log.Debugf("uploaded replica key %q", upload)
 	rw.Set("upload_s3_key", upload.PrefixString())
 
-	if me.StoreMetainfoFileAndTokenLocally {
+	if !me.NoStoreMetainfoFileAndTokenLocally {
 		var metainfoBytes bytes.Buffer
 		err = output.MetaInfo.Write(&metainfoBytes)
 		if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -98,7 +98,7 @@ func TestUploadAndDelete_DontSaveUploads(t *testing.T) {
 	input.RootUploadsDir = dir
 	input.AddUploadsToTorrentClient = false
 	input.StoreUploadsLocally = false
-	input.StoreMetainfoFileAndTokenLocally = false
+	input.NoStoreMetainfoFileAndTokenLocally = true
 	handler, err := NewHTTPHandler(input)
 	require.NoError(t, err)
 	defer handler.Close()


### PR DESCRIPTION
Fix for https://github.com/getlantern/replica/pull/54

This is to ensure healthy defaults (i.e., always store metainfo and token **unless** explicitly said otherwise)

## TODOs
- [ ] Change android-lantern to reflect this change