### PR TITLE
Add title & description metadata to the /object_info endpoint

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -988,9 +988,62 @@ func (me *HttpHandler) handleObjectInfo(rw InstrumentedResponseWriter, r *http.R
 	if err != nil {
 		return err
 	}
-	date := time.Unix(mi.CreationDate, 0).Format(time.RFC3339Nano)
+
+	metadata := make(map[string]interface{})
+	metadata["creationDate"] = time.Unix(mi.CreationDate, 0).Format(time.RFC3339Nano)
+
+	// Get metadata for torrent
+	mr := (&http.Request{
+		Method: http.MethodGet,
+		Header: make(http.Header),
+	}).WithContext(r.Context())
+	for _, h := range []string{
+		"Accept",
+		"Accept-Encoding",
+		"Accept-Language",
+		"Range",
+	} {
+		for _, v := range r.Header[h] {
+			mr.Header.Add(h, v)
+		}
+	}
+	gc := me.GlobalConfig()
+
+	key := fmt.Sprintf("%s/metadata", m.InfoHash.HexString())
+
+	resp, err = doFirst(mr, me.HttpClient, func(r *http.Response) bool {
+		return r.StatusCode/100 == 2
+	}, func() (ret []string) {
+		for _, s := range gc.GetMetadataBaseUrls() {
+			ret = append(ret, s+key)
+		}
+		return
+	}())
+
+	if err != nil {
+		if stdErrors.Is(err, r.Context().Err()) {
+			return err
+		}
+
+		log.Errorf("getting metadata: %w", err)
+		rw.Header().Set("Cache-Control", "public, max-age=86400, immutable")
+		return encodeJsonResponse(rw, metadata)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+		// Not all torrents have metadata files
+		rw.Header().Set("Cache-Control", "public, max-age=86400, immutable")
+		return encodeJsonResponse(rw, metadata)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	if err != nil {
+		return errors.New("doing json decode for metadata: %v", err)
+	}
+
 	rw.Header().Set("Cache-Control", "public, max-age=604800, immutable")
-	return encodeJsonResponse(rw, map[string]interface{}{"creationDate": date})
+	return encodeJsonResponse(rw, metadata)
 }
 
 // What a bad language.


### PR DESCRIPTION
~~This simply adds a new route, `/object_metadata`, that returns the new metadata we recently implemented (title and description, currently), if it exists. I chose the route of special-casing inside of `handleMetadata()` because otherwise it would have been a copy-and-paste of that function with one line changed. If you think this is too messy, I can redo it as its own function.~~

~~The choice of route name sucks here and I'm open to other suggestions I guess? We already use "metadata" to refer to the duration and thumbnail of files _inside the torrent_; however, the metadata I added in replica-rust applies to the _whole torrent_ and not individual files, which is why I had to fix up the key "path" in `handleMetadata()`. I don't know. This was the smallest change I could make to get title and description into the hands of the web UI. I'm open to other options if you think this should look different.~~

Edit 2022-08-09: after feedback I've changed this to piggy-back on the `/object_info` route. It will now return the title and description along with the creation date.

@woodybury, if you want to hack on the UI with this change before it gets merged and lantern-desktop gets updated, you can do the following in the `lantern-desktop` directory:

1. in `go.mod` add the following somewhere around line 25: `replace github.com/getlantern/replica => github.com/getlantern/replica surface-metadata`
2. Run `go mod tidy`
3. Run `go mod vendor`
4. `make` as usual. That should pull in this change.