### PR TITLE
Upload user-provided title and description

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -450,7 +450,9 @@ func (me *HttpHandler) handleUpload(rw InstrumentedResponseWriter, r *http.Reque
 		// Maybe we can differentiate form handling based on the method.
 	}
 
+	uploadOptions := service.NewUploadOptions(r)
 	fileName := r.URL.Query().Get("name")
+
 	var fileReader io.Reader
 	{
 		// There are streaming ways and helpers for temporary files for this if size becomes an issue.
@@ -498,7 +500,7 @@ func (me *HttpHandler) handleUpload(rw InstrumentedResponseWriter, r *http.Reque
 		}
 	}
 
-	output, err := me.ReplicaServiceClient.Upload(replicaUploadReader, fileName)
+	output, err := me.ReplicaServiceClient.Upload(replicaUploadReader, fileName, uploadOptions)
 	// me.GaSession.EventWithLabel("replica", "upload", path.Ext(fileName))
 	if me.OnRequestReceived != nil {
 		me.OnRequestReceived("upload", path.Ext(fileName))


### PR DESCRIPTION
With this, the lantern desktop (among other things?) can now add a title and description to an upload.

In testing, I saw issues if I didn't decode `replicaLink` before parsing it, so I added a decode step in both `handleUpload()`. I don't know if some or all of the other endpoints may need something similar, but opted to not preemptively add it in for the others.